### PR TITLE
Improvement: ParamStorerFromContext never return nil

### DIFF
--- a/paramstorer_context.go
+++ b/paramstorer_context.go
@@ -54,14 +54,14 @@ func ContextWithSafeAndUnsafeParams(ctx context.Context, safeParams, unsafeParam
 	return ContextWithParamStorers(ctx, NewSafeAndUnsafeParamStorer(safeParams, unsafeParams))
 }
 
-// ParamStorerFromContext returns the ParamStorer stored in the provided context. Returns nil if the provided context
-// does not contain a ParamStorer.
+// ParamStorerFromContext returns the ParamStorer stored in the provided context. Returns an empty ParamStorer if the
+// provided context does not contain one.
 func ParamStorerFromContext(ctx context.Context) ParamStorer {
 	val := ctx.Value(wParamsContextKey)
 	if paramStorer, ok := val.(ParamStorer); ok {
 		return paramStorer
 	}
-	return nil
+	return NewParamStorer()
 }
 
 // SafeAndUnsafeParamsFromContext returns the safe and unsafe parameters stored in the ParamStorer returned by


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
typical use case for `wparams.ParamStorerFromContext` is:
`werror.Params(wparams.ParamStorerFromContext(ctx))` current implementation results in a panic if the context is empty - as werror.Params(nil) panics.

## After this PR
`werror.Params(wparams.ParamStorerFromContext(context.Background()))` will not panic

==COMMIT_MSG==
<!-- User-facing outcomes this PR delivers -->
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-params/27)
<!-- Reviewable:end -->
