### PR TITLE
Performance improvements

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,0 +1,64 @@
+package wparams_test
+
+import (
+	"context"
+	"testing"
+
+	wparams "github.com/palantir/witchcraft-go-params"
+)
+
+func BenchmarkContextWithSafeParam(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		ctx := context.Background()
+		ctx = wparams.ContextWithSafeParam(ctx, "val1", 1)
+		ctx = wparams.ContextWithSafeParam(ctx, "val2", 2)
+		ctx = wparams.ContextWithSafeParam(ctx, "val3", 3)
+		_, _ = wparams.SafeAndUnsafeParamsFromContext(ctx)
+	}
+}
+
+func BenchmarkContextWithSafeParams(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		ctx := context.Background()
+		ctx = wparams.ContextWithSafeParams(ctx, map[string]interface{}{
+			"val1": 1,
+			"val2": 2,
+			"val3": 3,
+		})
+		_, _ = wparams.SafeAndUnsafeParamsFromContext(ctx)
+	}
+}
+
+func BenchmarkContextWithSafeAndUnsafeParam(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		ctx := context.Background()
+		ctx = wparams.ContextWithSafeParam(ctx, "safe1", 1)
+		ctx = wparams.ContextWithSafeParam(ctx, "safe2", 2)
+		ctx = wparams.ContextWithSafeParam(ctx, "safe3", 3)
+		ctx = wparams.ContextWithUnsafeParam(ctx, "unsafe1", 1)
+		ctx = wparams.ContextWithUnsafeParam(ctx, "unsafe2", 2)
+		ctx = wparams.ContextWithUnsafeParam(ctx, "unsafe3", 3)
+		_, _ = wparams.SafeAndUnsafeParamsFromContext(ctx)
+	}
+}
+
+func BenchmarkContextWithSafeAndUnsafeParams(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		ctx := context.Background()
+		ctx = wparams.ContextWithSafeParams(ctx, map[string]interface{}{
+			"safe1": 1,
+			"safe2": 2,
+			"safe3": 3,
+		})
+		ctx = wparams.ContextWithUnsafeParams(ctx, map[string]interface{}{
+			"unsafe1": 1,
+			"unsafe2": 2,
+			"unsafe3": 3,
+		})
+		_, _ = wparams.SafeAndUnsafeParamsFromContext(ctx)
+	}
+}

--- a/changelog/@unreleased/pr-49.v2.yml
+++ b/changelog/@unreleased/pr-49.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Reduce memory usage in ParamStorer utilities
+  links:
+  - https://github.com/palantir/witchcraft-go-params/pull/49

--- a/paramstorer.go
+++ b/paramstorer.go
@@ -29,7 +29,7 @@ func NewSafeParamStorer(safeParams map[string]interface{}) ParamStorer {
 	return NewSafeAndUnsafeParamStorer(safeParams, nil)
 }
 
-// NewSafeParam returns a new ParamStorer that stores a single unsafe parameter.
+// NewSafeParam returns a new ParamStorer that stores a single safe parameter.
 func NewSafeParam(key string, value interface{}) ParamStorer {
 	return singleParamStorer{key: key, value: value, safe: true}
 }

--- a/paramstorer.go
+++ b/paramstorer.go
@@ -1,7 +1,9 @@
 package wparams
 
 // ParamStorer is a type that stores safe and unsafe parameters. Keys should be unique across both SafeParams and
-// UnsafeParams (that is, if a key occurs in one map, it should not occur in the other).
+// UnsafeParams (that is, if a key occurs in one map, it should not occur in the other). For performance reasons,
+// the maps returned by SafeParams and UnsafeParams are references to the underlying storage and should not be modified
+// by the caller.
 type ParamStorer interface {
 	SafeParams() map[string]interface{}
 	UnsafeParams() map[string]interface{}
@@ -15,22 +17,11 @@ type ParamStorer interface {
 // example, if an unsafe key/value pair is provided by one ParamStorer and a later ParamStorer specifies a safe
 // key/value pair with the same key, the returned ParamStorer will store the last safe key/value pair).
 func NewParamStorer(paramStorers ...ParamStorer) ParamStorer {
-	safeParams := make(map[string]interface{})
-	unsafeParams := make(map[string]interface{})
+	collector := &mapParamStorer{}
 	for _, storer := range paramStorers {
-		if storer == nil {
-			continue
-		}
-		for k, v := range storer.SafeParams() {
-			safeParams[k] = v
-			delete(unsafeParams, k)
-		}
-		for k, v := range storer.UnsafeParams() {
-			unsafeParams[k] = v
-			delete(safeParams, k)
-		}
+		collector.copyFrom(storer)
 	}
-	return NewSafeAndUnsafeParamStorer(safeParams, unsafeParams)
+	return collector
 }
 
 // NewSafeParamStorer returns a new ParamStorer that stores the provided parameters as SafeParams.
@@ -38,25 +29,31 @@ func NewSafeParamStorer(safeParams map[string]interface{}) ParamStorer {
 	return NewSafeAndUnsafeParamStorer(safeParams, nil)
 }
 
+// NewSafeParam returns a new ParamStorer that stores a single unsafe parameter.
+func NewSafeParam(key string, value interface{}) ParamStorer {
+	return singleParamStorer{key: key, value: value, safe: true}
+}
+
 // NewUnsafeParamStorer returns a new ParamStorer that stores the provided parameters as UnsafeParams.
 func NewUnsafeParamStorer(unsafeParams map[string]interface{}) ParamStorer {
 	return NewSafeAndUnsafeParamStorer(nil, unsafeParams)
+}
+
+// NewUnsafeParam returns a new ParamStorer that stores a single unsafe parameter.
+func NewUnsafeParam(key string, value interface{}) ParamStorer {
+	return singleParamStorer{key: key, value: value, safe: false}
 }
 
 // NewSafeAndUnsafeParamStorer returns a new ParamStorer that stores the provided safe parameters as SafeParams and the
 // unsafe parameters as UnsafeParams. If the safeParams and unsafeParams have any keys in common, the key/value pairs in
 // the unsafeParams will be used (the conflicting key/value pairs provided by safeParams will be ignored).
 func NewSafeAndUnsafeParamStorer(safeParams, unsafeParams map[string]interface{}) ParamStorer {
-	storer := &mapParamStorer{
-		safeParams:   make(map[string]interface{}),
-		unsafeParams: make(map[string]interface{}),
-	}
+	storer := &mapParamStorer{}
 	for k, v := range safeParams {
-		storer.safeParams[k] = v
+		storer.putSafeParam(k, v)
 	}
 	for k, v := range unsafeParams {
-		storer.unsafeParams[k] = v
-		delete(storer.safeParams, k)
+		storer.putUnsafeParam(k, v)
 	}
 	return storer
 }
@@ -67,9 +64,82 @@ type mapParamStorer struct {
 }
 
 func (m *mapParamStorer) SafeParams() map[string]interface{} {
+	if m.safeParams == nil {
+		return map[string]interface{}{}
+	}
 	return m.safeParams
 }
 
 func (m *mapParamStorer) UnsafeParams() map[string]interface{} {
+	if m.unsafeParams == nil {
+		return map[string]interface{}{}
+	}
 	return m.unsafeParams
+}
+
+func (m *mapParamStorer) putSafeParam(k string, v interface{}) {
+	if m.safeParams == nil {
+		m.safeParams = map[string]interface{}{k: v}
+	} else {
+		m.safeParams[k] = v
+	}
+	delete(m.unsafeParams, k)
+}
+
+func (m *mapParamStorer) putUnsafeParam(k string, v interface{}) {
+	if m.unsafeParams == nil {
+		m.unsafeParams = map[string]interface{}{k: v}
+	} else {
+		m.unsafeParams[k] = v
+	}
+	delete(m.safeParams, k)
+}
+
+func (m *mapParamStorer) copyFrom(storer ParamStorer) {
+	if storer == nil {
+		return
+	}
+	// If this is one of our types, we can access the values directly and avoid intermediate map allocations.
+	switch st := storer.(type) {
+	case singleParamStorer:
+		if st.safe {
+			m.putSafeParam(st.key, st.value)
+		} else {
+			m.putUnsafeParam(st.key, st.value)
+		}
+	case *mapParamStorer:
+		for k, v := range st.safeParams {
+			m.putSafeParam(k, v)
+		}
+		for k, v := range st.unsafeParams {
+			m.putUnsafeParam(k, v)
+		}
+	default:
+		for k, v := range st.SafeParams() {
+			m.putSafeParam(k, v)
+		}
+		for k, v := range st.UnsafeParams() {
+			m.putUnsafeParam(k, v)
+		}
+	}
+}
+
+type singleParamStorer struct {
+	key   string
+	value interface{}
+	safe  bool
+}
+
+func (s singleParamStorer) SafeParams() map[string]interface{} {
+	if !s.safe {
+		return map[string]interface{}{}
+	}
+	return map[string]interface{}{s.key: s.value}
+}
+
+func (s singleParamStorer) UnsafeParams() map[string]interface{} {
+	if s.safe {
+		return map[string]interface{}{}
+	}
+	return map[string]interface{}{s.key: s.value}
 }

--- a/paramstorer_context.go
+++ b/paramstorer_context.go
@@ -19,9 +19,7 @@ func ContextWithParamStorers(ctx context.Context, params ...ParamStorer) context
 // provided context already has safe/unsafe params, the newly returned context will contain the result of merging the
 // previous parameters with the provided parameter.
 func ContextWithSafeParam(ctx context.Context, key string, value interface{}) context.Context {
-	return ContextWithSafeParams(ctx, map[string]interface{}{
-		key: value,
-	})
+	return ContextWithParamStorers(ctx, NewSafeParam(key, value))
 }
 
 // ContextWithSafeParams returns a copy of the provided context that contains the provided safe parameters. If the
@@ -35,9 +33,7 @@ func ContextWithSafeParams(ctx context.Context, safeParams map[string]interface{
 // provided context already has safe/unsafe params, the newly returned context will contain the result of merging the
 // previous parameters with the provided parameter.
 func ContextWithUnsafeParam(ctx context.Context, key string, value interface{}) context.Context {
-	return ContextWithUnsafeParams(ctx, map[string]interface{}{
-		key: value,
-	})
+	return ContextWithParamStorers(ctx, NewUnsafeParam(key, value))
 }
 
 // ContextWithUnsafeParams returns a copy of the provided context that contains the provided unsafe parameters. If the


### PR DESCRIPTION
I saw some of this library popping up in memory profiles, so decided to take a look at reducing the number of map creations/allocations. 

This PR should have no functional changes, but makes the following optimizations:
* Defer allocating empty maps for safeParams/unsafeParams until we know we have something to populate
* Add `singleParamStorer` for cases we know only contain one parameter
* When merging storers, check the underlying type to see if we can avoid going through the public API

Old benchmark:
```
BenchmarkContextWithSafeParam
BenchmarkContextWithSafeParam-16              	  418755	      2710 ns/op	    2640 B/op	      30 allocs/op
BenchmarkContextWithSafeParams
BenchmarkContextWithSafeParams-16             	 1000000	      1036 ns/op	     880 B/op	      10 allocs/op
BenchmarkContextWithSafeAndUnsafeParam
BenchmarkContextWithSafeAndUnsafeParam-16     	  178443	      6517 ns/op	    6144 B/op	      63 allocs/op
BenchmarkContextWithSafeAndUnsafeParams
BenchmarkContextWithSafeAndUnsafeParams-16    	  510159	      2384 ns/op	    2048 B/op	      21 allocs/op
```

New benchmark:
```
BenchmarkContextWithSafeParam
BenchmarkContextWithSafeParam-16              	  855843	      1388 ns/op	    1488 B/op	      19 allocs/op
BenchmarkContextWithSafeParams
BenchmarkContextWithSafeParams-16             	 1465884	       831 ns/op	     832 B/op	       9 allocs/op
BenchmarkContextWithSafeAndUnsafeParam
BenchmarkContextWithSafeAndUnsafeParam-16     	  318692	      3596 ns/op	    3888 B/op	      42 allocs/op
BenchmarkContextWithSafeAndUnsafeParams
BenchmarkContextWithSafeAndUnsafeParams-16    	  603049	      1998 ns/op	    1904 B/op	      18 allocs/op
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-params/49)
<!-- Reviewable:end -->
