### PR TITLE
improvement: New*ParamStorer and ContextWith*Params accept variadic map arguments

### DIFF
--- a/changelog/@unreleased/pr-133.v2.yml
+++ b/changelog/@unreleased/pr-133.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: New*ParamStorer and ContextWith*Params accept variadic map arguments
+  links:
+  - https://github.com/palantir/witchcraft-go-params/pull/133

--- a/paramstorer.go
+++ b/paramstorer.go
@@ -25,8 +25,14 @@ func NewParamStorer(paramStorers ...ParamStorer) ParamStorer {
 }
 
 // NewSafeParamStorer returns a new ParamStorer that stores the provided parameters as SafeParams.
-func NewSafeParamStorer(safeParams map[string]interface{}) ParamStorer {
-	return NewSafeAndUnsafeParamStorer(safeParams, nil)
+func NewSafeParamStorer(safeParams ...map[string]interface{}) ParamStorer {
+	storer := &mapParamStorer{}
+	for _, p := range safeParams {
+		for k, v := range p {
+			storer.putSafeParam(k, v)
+		}
+	}
+	return storer
 }
 
 // NewSafeParam returns a new ParamStorer that stores a single safe parameter.
@@ -35,8 +41,14 @@ func NewSafeParam(key string, value interface{}) ParamStorer {
 }
 
 // NewUnsafeParamStorer returns a new ParamStorer that stores the provided parameters as UnsafeParams.
-func NewUnsafeParamStorer(unsafeParams map[string]interface{}) ParamStorer {
-	return NewSafeAndUnsafeParamStorer(nil, unsafeParams)
+func NewUnsafeParamStorer(unsafeParams ...map[string]interface{}) ParamStorer {
+	storer := &mapParamStorer{}
+	for _, p := range unsafeParams {
+		for k, v := range p {
+			storer.putUnsafeParam(k, v)
+		}
+	}
+	return storer
 }
 
 // NewUnsafeParam returns a new ParamStorer that stores a single unsafe parameter.

--- a/paramstorer_context.go
+++ b/paramstorer_context.go
@@ -25,8 +25,8 @@ func ContextWithSafeParam(ctx context.Context, key string, value interface{}) co
 // ContextWithSafeParams returns a copy of the provided context that contains the provided safe parameters. If the
 // provided context already has safe/unsafe params, the newly returned context will contain the result of merging the
 // previous parameters with the provided parameters.
-func ContextWithSafeParams(ctx context.Context, safeParams map[string]interface{}) context.Context {
-	return ContextWithParamStorers(ctx, NewSafeParamStorer(safeParams))
+func ContextWithSafeParams(ctx context.Context, safeParams ...map[string]interface{}) context.Context {
+	return ContextWithParamStorers(ctx, NewSafeParamStorer(safeParams...))
 }
 
 // ContextWithUnsafeParam returns a copy of the provided context that contains the provided unsafe parameter. If the
@@ -39,8 +39,8 @@ func ContextWithUnsafeParam(ctx context.Context, key string, value interface{}) 
 // ContextWithUnsafeParams returns a copy of the provided context that contains the provided unsafe parameters. If the
 // provided context already has safe/unsafe params, the newly returned context will contain the result of merging the
 // previous parameters with the provided parameters.
-func ContextWithUnsafeParams(ctx context.Context, unsafeParams map[string]interface{}) context.Context {
-	return ContextWithParamStorers(ctx, NewUnsafeParamStorer(unsafeParams))
+func ContextWithUnsafeParams(ctx context.Context, unsafeParams ...map[string]interface{}) context.Context {
+	return ContextWithParamStorers(ctx, NewUnsafeParamStorer(unsafeParams...))
 }
 
 // ContextWithSafeAndUnsafeParams returns a copy of the provided context that contains the provided safe and unsafe


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-params/133)
<!-- Reviewable:end -->
